### PR TITLE
Specify date explicitly

### DIFF
--- a/grattan.cls
+++ b/grattan.cls
@@ -783,6 +783,7 @@ numbers=noenddot,
   uniquelist=false, 
   uniquename=init,
   sorting=anyt,
+  date=year, % else bibliography will be e.g. ATO (Jul. 10, 2016c)
   labelalpha,
   maxalphanames=1
 ]{biblatex}

--- a/grattan.cls
+++ b/grattan.cls
@@ -815,11 +815,11 @@ numbers=noenddot,
       \iftoggle{bbx:dowehavemorenames}
         {\printnames{labelname}%
          \setunit{\printdelim{nameyeardelim}}%
-         \usebibmacro{date+extrayear}%
+         \usebibmacro{date+extradate}%
          \space\space\newunit\newblock}
         {}%
     \endgroup
-    \iftoggle{bbx:dowehavemorenames}{\renewbibmacro*{date+extrayear}{}}{}%
+    \iftoggle{bbx:dowehavemorenames}{\renewbibmacro*{date+extradate}{}}{}%
   }
 }
 


### PR DESCRIPTION
In some locales, and with the more recent version of biblatex, the use of a date field will result in the bibliography appearing like

ATO (Jan. 10, 2017a). *Population and asset allocation tables*, Australian Taxation Office

This PR ensures that ATO (2017a) is used